### PR TITLE
[fix] - Point mainnet CID Checker to api-read-cid-checker-lotus-service

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/env-values/mainnet.yaml
+++ b/helm/env-values/mainnet.yaml
@@ -1,5 +1,5 @@
 dbSize: 30Gi
-lotusURL: "http://space06-lotus-service.network:1234/rpc/v0"
+lotusURL: "http://api-read-cid-checker-lotus-service.network:1234/rpc/v0"
 services:
   s3SortCaching:
     enabled: true


### PR DESCRIPTION
Due to the discontinuation of space06, pointing CID checker to the dedicated node from the public pool.